### PR TITLE
fix path when no emulate

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const puppeteer = require('puppeteer')
 const devices = require('puppeteer/DeviceDescriptors')
 const program = require('commander')
 
-var urlvalue, emulate = "";
+let urlvalue;
 
 program
     .option('--url, [url]', 'The url')
@@ -40,7 +40,10 @@ console.log(fullPage);
     const page = await browser.newPage()
     const timestamp = new Date().getTime()
     if (program.w && program.h) await page.setViewport({width: Number(program.w), height: Number(program.h)})
-    if (program.emulate) await page.emulate(devices[program.emulate]);
+    if (program.emulate)
+      await page.emulate(devices[program.emulate]);
+    else
+      program.emulate = '';
     if (program.auth) {
       const [username, password] = program.auth.split(';');
       await page.authenticate({username:username, password:password});


### PR DESCRIPTION
There is a `undefined` in the filename when no `emulate` passed.
It looks uncomfortable.
So simply use `''` instead when no `emulate` passed.

![screen shot 2018-12-06 at 10 14 45 pm](https://user-images.githubusercontent.com/23313266/49589577-b582c880-f9a4-11e8-92d9-4b623be7fe38.png)


