### PR TITLE
12 allow for just width or height. If height, fix fullPage

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,12 @@ console.log(fullPage);
     const browser = await puppeteer.launch()
     const page = await browser.newPage()
     const d = new Date()
-    if (program.w && program.h) await page.setViewport({width: Number(program.w), height: Number(program.h)})
+    if (program.w || program.h) {
+      const newWidth = !program.w?600:program.w
+      const newHeight = !program.h?'0':program.h
+      if (program.h && !program.fullpage) fullPage = false;
+      await page.setViewport({width: Number(newWidth), height: Number(newHeight)})
+    }
     if (program.emulate) await page.emulate(devices[program.emulate]);
     await page.goto(urlvalue)
     const title = await page.title()

--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ console.log(program.fullPage);
     if (program.w || program.h) {
       const newWidth = !program.w?600:program.w
       const newHeight = !program.h?'0':program.h
-      if (program.h && !program.fullpage) fullPage = false;
+      if (program.h && !program.fullpage) program.fullPage = false;
       await page.setViewport({width: Number(newWidth), height: Number(newHeight)})
     }
     if (program.emulate)


### PR DESCRIPTION
Re: #12 allowing for users to pass just `--w`, ` --h`, or both. 
Setting fallback values where needed.
* Just `--w` sets `h='0'` to respect the default fullPage=true;
  * This results in the specified width and full page height
* Just `--h` sets `w=600` to be consistent with chrome's default. Also sets fullPage=false if not explicitly declared.
  * This results in the default width of 600px and specified height
* Both `--w` and `--h` sets fullPage=false to respect specified height

This is a change from my proposed solution in #12; This solution may be more elegant as the code base grows. 