### PR TITLE
add new option --file to specify the name of the generated output image file

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Parameters:
 --auth - basic http authentication  
 --no - exclude "image", "stylesheet", "script", "font"  
 --click - example: ".selector>a" excellent way to close popups or to click some buttons on the page.
-
+--file - output file name (optional, otherwise based on page title and timestamp)
 <p>
 
 <h4>Example: </h4>
@@ -70,6 +70,8 @@ screenshoteer --url https://www.nytimes.com --no "script"
 screenshoteer --url https://www.economist.com/ --click ".ribbon__close-button"
 
 screenshoteer --url file:///Users/../index.html
+
+screenshoteer --url https://www.slashdot.org --file /tmp/slashdot.png
 ```
 <p> List of of supported mobile devices: https://github.com/GoogleChrome/puppeteer/blob/master/DeviceDescriptors.js
 </p>

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ program
     .option('--auth, [auth]', 'Basic HTTP authentication')
     .option('--no, [no]', 'Exclude')
     .option('--click, [click]', 'Click')
+    .option('--file, [file]', 'Output file')
     .parse(process.argv);
 
 if (!program.url) {
@@ -69,11 +70,12 @@ console.log(program.fullPage);
     const title = (await page.title()).replace(/[/\\?%*:|"<>]/g, '-');
     if (program.waitfor) await page.waitFor(Number(program.waitfor));
     if (program.click) await page.click(program.click);
+    const file = program.file ? program.file : `${title} ${program.emulate} ${program.el} ${timestamp}.png`;
     if (program.el) {
       const el = await page.$(program.el);
-      await el.screenshot({path: `${title} ${program.emulate} ${program.el} ${timestamp}.png`});
+      await el.screenshot({path: file});
     } else {
-      await page.screenshot({path: `${title} ${program.emulate} ${timestamp}.png`, fullPage: program.fullPage});
+      await page.screenshot({path: file, fullPage: program.fullPage});
     }
     await page.emulateMedia('screen');
     if (program.pdf) await page.pdf({path: `${title} ${program.emulate} ${timestamp}.pdf`});


### PR DESCRIPTION
I'm using screenshoteer from within a script where the name of the generated image file has to be predetermined (to enable further processing), so I added a `--file /tmp/outputfile.png` option.
